### PR TITLE
Read from standard input

### DIFF
--- a/codec.go
+++ b/codec.go
@@ -30,7 +30,14 @@ type Decoder interface {
 type ConversionFunc func(r io.Reader, w io.Writer, options Options) error
 
 func ConvertFormats(inFilename, outFilename string, conversionFunc ConversionFunc, options Options) error {
-    inFile, err := os.Open(inFilename)
+    var inFile *os.File
+    var err error
+
+    if inFilename == "-" {
+        inFile = os.Stdin
+    } else {
+        inFile, err = os.Open(inFilename)
+    }
     if err != nil {
         return err
     }

--- a/main.go
+++ b/main.go
@@ -25,16 +25,16 @@ import (
 const usage = `msgpack-cli
 
 Usage:
-    msgpack-cli encode <input-file> [--out=<output-file>] [--disable-int64-conv]
-    msgpack-cli decode <input-file> [--out=<output-file>] [--pp]
+    msgpack-cli encode [<input-file>] [--out=<output-file>] [--disable-int64-conv]
+    msgpack-cli decode [<input-file>] [--out=<output-file>] [--pp]
     msgpack-cli rpc <host> <port> <method> [<params>|--file=<input-file>] [--pp]
         [--timeout=<timeout>][--disable-int64-conv]
     msgpack-cli -h | --help
     msgpack-cli --version
 
 Commands:
-    encode                Encode data from input file to STDOUT
-    decode                Decode data from input file to STDOUT
+    encode                Encode data from input file (default STDIN) to STDOUT
+    decode                Decode data from input file (default STDIN) to STDOUT
     rpc                   Call RPC method and write result to STDOUT
 
 Options:
@@ -70,7 +70,13 @@ func main() {
 
     switch {
     case arguments["encode"], arguments["decode"]:
-        inFilename := arguments["<input-file>"].(string)
+        var inFilename string
+        if arguments["<input-file>"] != nil {
+            inFilename = arguments["<input-file>"].(string)
+        } else {
+            inFilename = "-"
+        }
+
         outFilename, _ := arguments["--out"].(string)
 
         conversionFunc := ConvertJSON2Msgpack


### PR DESCRIPTION
If you currently want to pipe data into msgpack-cli, you will have to do stuff like `cat <file>.msgpack | msgpack-cli decode /dev/stdin | [...]` which is slightly cumbersome. It would be nice if this was easier, as also requested in #1.

This PR adds support for specifying `"-"` as the input file which will then be "translated"  to standard input. I've also made the input file optional to the encode and decode functions, and made them default to standard input as well. This behaviour matches that of many, many Unix command line tools and should mean this tool feels more familiar to people who pick it up for the first time.